### PR TITLE
Make lata attribute lowercase

### DIFF
--- a/resource_phonenumber_funcs.go
+++ b/resource_phonenumber_funcs.go
@@ -39,8 +39,7 @@ func phonenumberCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	//numbers, err := twilioc.GetLocalAvailablePhoneNumbers(
-    numbers, err := twilioc.GetMobileAvaliablePhoneNumber(
+	numbers, err := twilioc.GetLocalAvailablePhoneNumbers(
 		m.Client,
 		d.Get("iso_country_code").(string),
 		filters...,

--- a/resource_phonenumber_funcs.go
+++ b/resource_phonenumber_funcs.go
@@ -39,7 +39,8 @@ func phonenumberCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	numbers, err := twilioc.GetLocalAvailablePhoneNumbers(
+	//numbers, err := twilioc.GetLocalAvailablePhoneNumbers(
+    numbers, err := twilioc.GetMobileAvaliablePhoneNumber(
 		m.Client,
 		d.Get("iso_country_code").(string),
 		filters...,

--- a/resource_phonenumber_funcs.go
+++ b/resource_phonenumber_funcs.go
@@ -33,7 +33,7 @@ func phonenumberCreate(d *schema.ResourceData, meta interface{}) error {
 				filters = append(filters, twilioc.InPostalCode(v.(string)))
 			case "rate_center":
 				filters = append(filters, twilioc.InRateCenter(v.(string)))
-			case "LATA":
+			case "lata":
 				filters = append(filters, twilioc.InLata(v.(string)))
 			}
 		}

--- a/resource_phonenumber_schema.go
+++ b/resource_phonenumber_schema.go
@@ -69,7 +69,7 @@ func resourcePhonenumber() *schema.Resource {
 							Description: "Limit results to a specific rate center, or given a phone number search within the same rate center as that number. Requires InLata to be set as well.",
 							Optional:    true,
 						},
-						"LATA": &schema.Schema{
+						"lata": &schema.Schema{
 							Type:        schema.TypeString,
 							Description: "Limit results to a specific Local access and transport area (LATA). Given a phone number, search within the same LATA as that number.",
 							Optional:    true,


### PR DESCRIPTION
Terraform doesn't support uppercase attribute names anymore so the plugin was breaking when compiled against new versions.